### PR TITLE
Add python-cloudflare to included forks.

### DIFF
--- a/static/javascripts/script.js
+++ b/static/javascripts/script.js
@@ -82,6 +82,7 @@
 		'vpnc-scripts'];
 
 	var includeForks = [
+        'python-cloudflare',
 		'zlib',
 		'lua-cmsgpack'
 	];

--- a/static/javascripts/script.js
+++ b/static/javascripts/script.js
@@ -82,7 +82,7 @@
 		'vpnc-scripts'];
 
 	var includeForks = [
-        'python-cloudflare',
+		'python-cloudflare',
 		'zlib',
 		'lua-cmsgpack'
 	];


### PR DESCRIPTION
The fact that python-cloudflare is technically a fork
escaped my notice.  Make sure it shows up in the "Automate"
section of the page by including it.