### PR TITLE
Fix fork inclusion, add python-cloudflare to inclusion list

### DIFF
--- a/static/javascripts/script.js
+++ b/static/javascripts/script.js
@@ -245,7 +245,7 @@
 				repos = $.grep(repos, function(value) {
 					var keep = exclude.indexOf(value.name) === -1,
 						found = false;
-					if( value.fork && !(value.name in includeForks) ){
+					if( value.fork && (includeForks.indexOf(value.name) === -1) ){
 						// ignore most forks.
 						keep = false;
 					}

--- a/static/javascripts/script.js
+++ b/static/javascripts/script.js
@@ -82,6 +82,7 @@
 		'vpnc-scripts'];
 
 	var includeForks = [
+		'python-cloudflare',
 		'zlib',
 		'lua-cmsgpack'
 	];


### PR DESCRIPTION
python-cloudflare was missing from the inclusion check because I didn't notice it was a fork.
I also didn't notice the that the inclusion check wasn't working at all.  \*headdesk\* x 9000.