### PR TITLE
Make the site HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 cloudflare.github.io
 ====================
 
-The source code of http://cloudflare.github.io/
+The source code of https://cloudflare.github.io/
 
 LICENSE
 -------
 
 Copyright 2013 CloudFlare, Inc.
 
-Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+Licensed under the Apache License, Version 2.0: https://www.apache.org/licenses/LICENSE-2.0

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 			<ul class="unstyled">
 				<li><a href="https://www.cloudflare.com">Cloudflare</a></li>
 				<li><a href="https://www.cloudflare.com/careers">Careers</a></li>
-				<li><a href="http://blog.cloudflare.com">Blog</a></li>
+				<li><a href="https://blog.cloudflare.com">Blog</a></li>
 			</ul>
 		</div>
 	</div><!-- /.overview -->
@@ -56,7 +56,7 @@
 			<li><a href="https://twitter.com/cloudflare">Twitter</a></li>
 			<li><a href="https://facebook.com/Cloudflare">Facebook</a></li>
 			<li><a href="https://plus.google.com/+cloudflare/posts">Google+</a></li>
-			<li><a href="http://www.linkedin.com/company/cloudflare-inc.">Linkedin</a></li>
+			<li><a href="https://www.linkedin.com/company/cloudflare-inc-">Linkedin</a></li>
 		</p>
 	</footer>
 	<!-- /#footer -->

--- a/static/javascripts/script.js
+++ b/static/javascripts/script.js
@@ -89,12 +89,12 @@
 
 	var customRepos = [{
 		name : 'stapxx',
-		html_url : 'http://github.com/agentzh/stapxx',
+		html_url : 'https://github.com/agentzh/stapxx',
 		language : 'Perl',
 		description : 'Simple macro language extentions to systemtap'
 	},{
 		name : 'nginx-systemtap-toolkit',
-		html_url : 'http://github.com/agentzh/nginx-systemtap-toolkit',
+		html_url : 'https://github.com/agentzh/nginx-systemtap-toolkit',
 		language : 'Perl',
 		description : 'Real-time analyzing and diagnosing tools for Nginx based on SystemTap'
 	},{


### PR DESCRIPTION
This PR changes all URLs to use HTTPS instead of HTTP, however Cloudflare staff will still have to [turn on the **Enforce HTTPS** option in the repository settings](https://help.github.com/articles/securing-your-github-pages-site-with-https/).